### PR TITLE
fix: use full Xcode for app bundle builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Requirements:
 - Swift 6 toolchain
 - Xcode with `actool` for app icon compilation
 
+The bundle script uses `DEVELOPER_DIR` when it is set. If `xcode-select` points
+at the standalone Command Line Tools, it automatically uses an Xcode app from
+`/Applications` without changing the system-wide developer directory.
+
 Run tests:
 
 ```sh

--- a/Scripts/build-app-bundle.sh
+++ b/Scripts/build-app-bundle.sh
@@ -14,6 +14,24 @@ SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-}"
 CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
 APP_ICON_DOCUMENT="${APP_ICON_DOCUMENT:-$PACKAGE_DIR/Resources/minecraft-bedrock.icon}"
 APP_ICON_NAME="${APP_ICON_NAME:-${APP_ICON_DOCUMENT:t:r}}"
+
+# SwiftUI macros and Icon Composer's actool are only shipped with full Xcode.
+# Prefer the caller's selection, but recover locally when xcode-select points at
+# the standalone Command Line Tools and an Xcode installation is available.
+if [[ -z "${DEVELOPER_DIR:-}" && "$(xcode-select -p 2>/dev/null || true)" == */CommandLineTools ]]; then
+  xcode_developer_dirs=(
+    /Applications/Xcode.app/Contents/Developer
+    /Applications/Xcode-*.app/Contents/Developer(N)
+  )
+  for xcode_developer_dir in "${xcode_developer_dirs[@]}"; do
+    if [[ -x "$xcode_developer_dir/usr/bin/actool" ]]; then
+      export DEVELOPER_DIR="$xcode_developer_dir"
+      echo "Using Xcode developer directory: $DEVELOPER_DIR" >&2
+      break
+    fi
+  done
+fi
+
 ACTOOL="${ACTOOL:-$(xcrun --find actool 2>/dev/null || true)}"
 MACOS_DEPLOYMENT_TARGET="${MACOS_DEPLOYMENT_TARGET:-14.0}"
 


### PR DESCRIPTION
## Summary

- detect when `xcode-select` points to standalone Command Line Tools
- use an installed full Xcode locally without changing the system-wide developer directory
- document `DEVELOPER_DIR` behavior and the automatic fallback

## Root cause

The standalone Command Line Tools can expose the macOS SDK and SwiftUI interfaces without shipping the `SwiftUIMacros` host plugin. Bundle builds then produce missing macro diagnostics for every `@State` property and cascading immutability errors.

## Impact

Developers with full Xcode installed can run `Scripts/build-app-bundle.sh` even when their global `xcode-select` setting still points to Command Line Tools. Explicit `DEVELOPER_DIR` selections continue to take precedence.

## Validation

- built the `MinecraftBedrockLauncher` release product
- ran the complete `Scripts/build-app-bundle.sh` workflow
- verified the generated bundle signature with `codesign --verify --deep --strict`
- verified the arm64 launcher executable and compiled icon resources